### PR TITLE
V0.3.0 aafs emily streetman zonescaptions

### DIFF
--- a/docs/forensics-anthro-guide/zones.md
+++ b/docs/forensics-anthro-guide/zones.md
@@ -1,6 +1,6 @@
 In this section we present the images used in the Zonation Method for inventory of fragmented human remains.
-#Skull
-##Cranium
+# Skull
+## Cranium
 ![Skull anterior](cora-docs/docs/images/zones/Clavicle_left_200.png)
 ![Skull lateral right](/images/logo.png)
 ![Skull lateral left](/images/logo.png)
@@ -8,70 +8,69 @@ In this section we present the images used in the Zonation Method for inventory 
 ![Skull inferior](/images/logo.png)
 ![Skull superior](/images/logo.png)
 
-##Mandible
+## Mandible
 ![Mandible left](/images/logo.png)
 ![Mandible right](/images/logo.png)
 
-#Postcranial remains
-##Vertebrae
-###Cervical vertebrae
+# Postcranial remains
+## Vertebrae
+### Cervical vertebrae
 ![Cervical vertebra](/images/logo.png)
 
-###Thoracic vertebrae
+### Thoracic vertebrae
 ![Thoracic vertebra](/images/logo.png)
 
-###Lumbar vertebrae
+### Lumbar vertebrae
 ![Lumbar vertebra](/images/logo.png)
 
-###Sacrum
+### Sacrum
 ![Sacrum](/images/logo.png)
 
-##Thorax and Shoulder
-###Rib 1
+## Thorax and Shoulder
+### Rib 1
 ![Rib1](/images/logo.png)
 
-###Ribs 2-12
+### Ribs 2-12
 ![Ribs](/images/logo.png)
 
-###Sternum
+### Sternum
 ![Sternum](/images/logo.png)
 
-###Clavicle
+### Clavicle
 ![Clavicle](/images/logo.png)
 
-###Scapula
+### Scapula
 ![Scapula](/images/logo.png)
 
-##Upper limb
-###Humerus
+## Upper limb
+### Humerus
 ![Humerus](/images/logo.png)
 
-###Radius
+### Radius
 ![Radius](/images/logo.png)
 
-###Ulna
+### Ulna
 ![Ulna](/images/logo.png)
 
-##Pelvis and Lower Limb
-###Os coxa
+## Pelvis and Lower Limb
+### Os coxa
 ![Os coxa](/images/logo.png)
 
-###Femur
+### Femur
 ![Femur](/images/logo.png)
 
-###Patella
+### Patella
 ![Patella](/images/logo.png)
 
-###Tibia
+### Tibia
 ![Tibia](/images/logo.png)
 
-###Fibula
+### Fibula
 ![Fibula](/images/logo.png)
 
-##Hands and Feet
-###Hand
+## Hands and Feet
+### Hand
 ![Hand](/images/logo.png)
 
-
-###Foot
+### Foot
 ![Foot](/images/logo.png)

--- a/docs/forensics-anthro-guide/zones.md
+++ b/docs/forensics-anthro-guide/zones.md
@@ -1,76 +1,88 @@
 In this section we present the images used in the Zonation Method for inventory of fragmented human remains.
-# Skull
-## Cranium
-![Skull anterior](cora-docs/docs/images/zones/Clavicle_left_200.png)
-![Skull lateral right](/images/logo.png)
-![Skull lateral left](/images/logo.png)
-![Skull posterior](/images/logo.png)
-![Skull inferior](/images/logo.png)
-![Skull superior](/images/logo.png)
+# **SKULL**
+## **Cranium**
+![Skull anterior](/docs/images/zones/)
+![Skull lateral right](/docs/images/zones/)
+![Skull lateral left](/docs/images/zones/)
+![Skull posterior](/docs/images/zones/)
+![Skull inferior](/docs/images/zones/)
+![Skull superior](/docs/images/zones/)
 
-## Mandible
-![Mandible left](/images/logo.png)
-![Mandible right](/images/logo.png)
 
-# Postcranial remains
-## Vertebrae
+## **Mandible**
+![Mandible left](/docs/images/zones/Mandible_left_500.png)
+
+*Left mandible. Above: medial/internal view, below: lateral/external view.*
+
+**Zone descriptions**
+1. The portion of the corpus, including the alveoli for the premolars and molars as well as the premolars and molars themselves
+2. The portion of the corpus, including the alveolus fo rthe canine and the canine itself
+3. The area of the ascending ramus inferior to the coronoid process
+4. The coronoid process
+5. The mandibular condyle
+6. The gonial angle, including the mandibular foramen and mylohyoid groove (internally) and the attachment of M. masseter externally)
+7. The anterior portion of the corpus, includin the alveoli of the icisors and the incisors themselves
+
+![Mandible right](/docs/images/zones/Mandible_right_500.png)
+
+
+
+# **POSTCRANIAL REMAINS**
+## **Vertebrae**
 ### Cervical vertebrae
-![Cervical vertebra](/images/logo.png)
+![Cervical vertebra](/docs/images/zones/cervical_500.png)
 
-### Thoracic vertebrae
-![Thoracic vertebra](/images/logo.png)
-
-### Lumbar vertebrae
-![Lumbar vertebra](/images/logo.png)
+### Thoracic and lumbar vertebrae
+![Thoracic vertebra](/docs/images/zones/thoracic_500.png)
 
 ### Sacrum
-![Sacrum](/images/logo.png)
+![Sacrum](/docs/images/zones/Sacrum_500.png)
 
-## Thorax and Shoulder
+## **Thorax and Shoulder**
 ### Rib 1
-![Rib1](/images/logo.png)
+![Rib1](/docs/images/zones/rib01_500.png)
 
 ### Ribs 2-12
-![Ribs](/images/logo.png)
+![Ribs](/docs/images/zones/ribs_500.png)
 
 ### Sternum
-![Sternum](/images/logo.png)
+![Sternum](/docs/images/zones/Sternum_500.png)
 
 ### Clavicle
-![Clavicle](/images/logo.png)
+![Clavicle](/docs/images/zones/Clavicle_left_500.png)
 
 ### Scapula
-![Scapula](/images/logo.png)
+![Scapula](/docs/images/zones/Scapula_left_500.png)
 
-## Upper limb
+## **Upper limb**
 ### Humerus
-![Humerus](/images/logo.png)
+![Humerus](/docs/images/zones/Humerus_Left_500.png)
 
 ### Radius
-![Radius](/images/logo.png)
+![Radius](/docs/images/zones/Radius_left_500.png)
 
 ### Ulna
-![Ulna](/images/logo.png)
+![Ulna](/docs/images/zones/Ulna_left_500.png)
 
-## Pelvis and Lower Limb
+## **Pelvis and Lower Limb**
 ### Os coxa
-![Os coxa](/images/logo.png)
+![Os coxa](/docs/images/zones/Oscoxa_left_500.png)
 
 ### Femur
-![Femur](/images/logo.png)
+![Femur](/docs/images/zones/Femur3_500.png)
 
 ### Patella
-![Patella](/images/logo.png)
+![Patella](/docs/images/zones/patella_500.png)
 
 ### Tibia
-![Tibia](/images/logo.png)
+![Tibia](/docs/images/zones/Tibia_left_500.png)
 
 ### Fibula
-![Fibula](/images/logo.png)
+![Fibula](/docs/images/zones/fibula_500.png)
 
-## Hands and Feet
+## **Hands and Feet**
 ### Hand
-![Hand](/images/logo.png)
+![Hand](/docs/images/zones/Hand_left_500.png)
 
 ### Foot
-![Foot](/images/logo.png)
+![Foot](/docs/images/zones/Foot_right_500.png)

--- a/docs/forensics-anthro-guide/zones.md
+++ b/docs/forensics-anthro-guide/zones.md
@@ -2,19 +2,99 @@ In this section we present the images used in the Zonation Method for inventory 
 # **SKULL**
 ## **Cranium**
 ![Skull anterior](/docs/images/zones/)
+
+**Skull, anterior view.**
+
+*Zone descriptions*
+1. Right frontal, split sagittally through the metopic suture
+2. Left frontal, split sagittally through the juvenile metopic suture
+3. Right parietal
+4. Left parietal
+6. Left temporal, including the root of the zygomatic process from the left side
+7. Right temporal, including the root of thez ygomatic process from the right side
+10. Left zygoma
+11. Right zygoma
+12. Left maxilla
+13. Right maxilla
+14. Left nasal bone
+15. Right nasal bone
+
 ![Skull lateral right](/docs/images/zones/)
+
+**Skull, lateral right view**
+
+*Zone descriptions*
+1. Right frontal, split sagittally through the metopic suture
+3. Right parietal
+5. Occipital
+7. Right temporal, including the root of thez ygomatic process from the right side
+9. Right sphenoid
+11. Right zygoma
+13. Right maxilla
+15. Right nasal bone
+
 ![Skull lateral left](/docs/images/zones/)
+
+**Skull, lateral left view**
+
+*Zone descriptions*
+2. Left frontal, split sagittally through the juvenile metopic suture
+4. Left parietal
+5. Occipital
+6. Left temporal, including the root of the zygomatic process from the left side
+8. Left sphenoid
+10. Left zygoma
+12. Left maxilla
+14. Left nasal bone
+
 ![Skull posterior](/docs/images/zones/)
+**Skull, posterior view**
+
+*Zone descriptions*
+3. Right parietal
+4. Left parietal
+5. Occipital
+6. Left temporal, including the root of the zygomatic process from the left side
+7. Right temporal, including the root of thez ygomatic process from the right side
+
 ![Skull inferior](/docs/images/zones/)
+**Skull, inferior view**
+
+*Zone descriptions*
+3. Right parietal
+4. Left parietal
+5. Occipital
+6. Left temporal, including the root of the zygomatic process from the left side
+7. Right temporal, including the root of thez ygomatic process from the right side
+8. Left sphenoid
+9. Right sphenoid
+10. Left zygoma
+11. Right zygoma
+12. Palatal process of the left maxilla
+13. Palatal proces of the right maxilla
+
+
 ![Skull superior](/docs/images/zones/)
+**Skull, superior view**
+
+*Zone descriptions*
+1. Right frontal, split sagittally through the metopic suture
+2. Left frontal, split sagittally through the juvenile metopic suture
+3. Right parietal
+4. Left parietal
+5. Occipital
+6. Left temporal, including the root of the zygomatic process from the left side
+7. Right temporal, including the root of thez ygomatic process from the right side
+14. Left nasal bone
+15. Right nasal bone
 
 
 ## **Mandible**
 ![Mandible left](/docs/images/zones/Mandible_left_500.png)
 
-*Left mandible. Above: medial/internal view, below: lateral/external view.*
+**Left mandible. Above: medial/internal view, below: lateral/external view.**
 
-**Zone descriptions**
+*Zone descriptions*
 1. The portion of the corpus, including the alveoli for the premolars and molars as well as the premolars and molars themselves
 2. The portion of the corpus, including the alveolus fo rthe canine and the canine itself
 3. The area of the ascending ramus inferior to the coronoid process
@@ -25,6 +105,17 @@ In this section we present the images used in the Zonation Method for inventory 
 
 ![Mandible right](/docs/images/zones/Mandible_right_500.png)
 
+**Right mandible. Above: medial/internal view, below: lateral/external view.**
+
+*Zone descriptions*
+8. The portion of the corpus, including the alveoli for the premolars and molars as well as the premolars and molars themselves
+9. The portion of the corpus, including the alveolus fo rthe canine and the canine itself
+10. The area of the ascending ramus inferior to the coronoid process
+11. The coronoid process
+12. The mandibular condyle
+13. The gonial angle, including the mandibular foramen and mylohyoid groove (internally) and the attachment of M. masseter externally)
+14. The anterior portion of the corpus, includin the alveoli of the icisors and the incisors themselves
+
 
 
 # **POSTCRANIAL REMAINS**
@@ -32,53 +123,194 @@ In this section we present the images used in the Zonation Method for inventory 
 ### Cervical vertebrae
 ![Cervical vertebra](/docs/images/zones/cervical_500.png)
 
+**Cervical vertebra. Left: superior view, right: lateral view.**
+
+*Zone descriptions*
+1. Body
+2. Right transverse process, including the pedicle, pars interaticularis, and articular facets
+3. Left transverse process, including the pedicle, pars interaticularis, and aricular facets
+4. Spinous process
+
 ### Thoracic and lumbar vertebrae
 ![Thoracic vertebra](/docs/images/zones/thoracic_500.png)
+**Thoracic vertebra (also applies to lumbar vertebrae). Left: superior view, right: lateral view.**
+
+*Zone descriptions*
+1. Body
+2. Right transverse process, including the pedicle, pars interaticularis, and articular facets
+3. Left transverse process, including the pedicle, pars interaticularis, and aricular facets
+4. Spinous process
 
 ### Sacrum
 ![Sacrum](/docs/images/zones/Sacrum_500.png)
+**Sacrum. Left: anterior view, right: posterior view.**
+
+*Zone descriptions*
+1. Body
+2. Right transverse process, including the pedicle, pars interaticularis, and articular facets
+3. Left transverse process, including the pedicle, pars interaticularis, and aricular facets
+4. Spinous process
 
 ## **Thorax and Shoulder**
 ### Rib 1
 ![Rib1](/docs/images/zones/rib01_500.png)
+**Left rib 1. Above: inferior view, below: superior view.**
+
+*Zone descriptions*
+1. Head
+2. Area of the angle of the rib, including the articular and non-articular costal facets in ribs 1 through 10
+3. Remaining corpus and sternal end
 
 ### Ribs 2-12
 ![Ribs](/docs/images/zones/ribs_500.png)
+**Left rib 7. Above: inferior view, below: superior view.**
+
+*Zone descriptions*
+1. Head
+2. Area of the angle of the rib, including the articular and non-articular costal facets in ribs 1 through 10
+3. Remaining corpus and sternal end
 
 ### Sternum
 ![Sternum](/docs/images/zones/Sternum_500.png)
+**Sternum. Left: anterior view, right: posterior view.**
+
+*Zone descriptions*
+1. Manubrium
+2. Corpus sterni
+3. Xiphoid process
 
 ### Clavicle
 ![Clavicle](/docs/images/zones/Clavicle_left_500.png)
+**Left clavicle. Above: superior view, below: inferior view.**
+
+*Zone descriptions*
+1. Sternal end, including the area fo the atachment fo rthe cost-clavicular ligament
+2. Acromial end, including the conoid tubecle and trapezoid line, the attachments for the two components of the coraco-clavicular ligament
+3. Diaphysis, including the groove which marks the attachment for M. subclavius
 
 ### Scapula
 ![Scapula](/docs/images/zones/Scapula_left_500.png)
+**Left scapula. Left: anterior view, right: posterior view.**
+
+*Zone descriptions*
+1. Coracoid process
+2. Superior half of the gelnoid cavity
+3. Inferior half of the glenoid cavity
+4. Acromial end and axillary third of the spine
+5. Axillary third of the squamous portion and spine, including the neck and the area inferior to the coracoid process
+6. Middle third of the supraspinous fossa
+7. Axillary half of the squamous portion inferior to the spine, including the infraspinous fossa
+8. Vertebral third of the squamous portion and spine, including the attachment for M. rhomboideus major and suprasprinous fossa
+9. Vertebral half of the squamous portion inferior to the spine, including the infraspinous fossa
 
 ## **Upper limb**
 ### Humerus
 ![Humerus](/docs/images/zones/Humerus_Left_500.png)
+**Left humerus. Left: posterior view, right: anterior view.**
+
+*Zone descriptions*
+1. Greater and lesser tubercles
+2. Caput
+3. Lateral epicondyle
+4. Medial epicondyle
+5. Lateral articular process (capitulum) of the condyle
+6. Medial articular process (trochlea) of the condyle
+7. Distal lateral half of the diaphysis, including one-half of the olecranon fossa and the radial fossa
+8. Distal medial half of the diaphysis, including one-half of the olecranon fosssa and the coronoid fossa, including the nutrient forament
+9. Area surroudning the deltoid tuberosity
+10. Area opposite 9 making up one-half of the diaphysis longitudinally in the sagittal plane and cutting the bone transversely from medial to lateral
+11. Proximal portion of the diaphysis, including the surgical neck
 
 ### Radius
 ![Radius](/docs/images/zones/Radius_left_500.png)
+**Left radius. Left: posterior view, right: anterior view.**
+
+*Zone descriptions*
+1. Lateral half of the radial head
+2. Medial half of the radial head
+3. Lateral portion of the distal articulation
+4. Medial portion of the distal articulation
+5. Proximal portion of the diaphysis, including the radial tuberosity
+6. Lateral half o fthe diaphysis to the mid-point of the diaphysis, including the attachment for M. pronator teres
+7. Medial half of diaphysis to the mid-point of the diaphysis, opposite zone 6, including hte nutrient forament, which is located antero-medially
+8. Superior half of the distal third of the radius
+9. Lateral distal third of the diaphysis
+10. Medial distal third of the diaphysis
+11. Styloid process of the distal end
 
 ### Ulna
 ![Ulna](/docs/images/zones/Ulna_left_500.png)
+**Left ulna. Left: posterior view, right: anterior view.**
+
+*Zone descriptions*
+1. Olecranon process
+2. Area of the trochlear or semi-lunar notch, including the coronoid process
+3. Radial notch
+4. Proximal half of the diaphysis distal to area C
+5. Middle portion of the shaft
+6. Superior one-half of the distal third of the diaphysis
+7. Distal half of the distal third of the shaft, including the attachment of M. pronator quadratus
+8. Styloid process and head, including the posterior groove for M. extensor carpi ulnaris
 
 ## **Pelvis and Lower Limb**
 ### Os coxa
 ![Os coxa](/docs/images/zones/Oscoxa_left_500.png)
+**Left os coxa. Left: medial/internal view, right: lateral/external view.**
+
+*Zone descriptions*
+1. Superior portion of the acetabulum and adjoining areas anteriorly and posteriorly
+2. Posterior half of the inferior portion of the acetabulum and adjoining areas
+3. Anterior half of the inferior portion of the acetabulum and adjoining areas
+4. Superior portion of the ischium, including the ischial spine
+5. Inferior portion of the ilium, including the greater sicatic notch
+6. Superior portion of the ischial tuberosity
+7. Auricular surface of the ilium
+8. Superior portion of the pubis possessing the pectineal line and pubic tubercle
+9. Inferior portion of the pubis, including the pubic symphysis
+10. Greater part of the ilium, marked in an atnero-posterior diretion by a line running from just inferior to the anterior superior iliac spine to the posterior inferior iliac spine, but not including the iliac ccrest (superiorly)
+11. Inferior portion of the ischial tuberosity
+12. Iliac crest
 
 ### Femur
 ![Femur](/docs/images/zones/Femur3_500.png)
+**Left femur. Left: posterior view, right: anterior view.**
+
+*Zone descriptions*
+1. Greater trochanter
+2. Area around the lesser trochanter and the lesser trochanter
+3. Area of the cranial attachment of M. gluteus maximus
+4. Caput
+5. Neck of the element and area along the inter-trochanteric line (anteriorly) and intertrochanteric crest (posteriorly)
+6. Middle poriton of the diaphysis to the point where the linea aspera bifurcates into the supra-condylar lines, including the nutrient forament, which is located posteriorly
+7. Lateral half of the distal third of the diaphysis split longitudinally in the sagittal plance, including one-half of the popliteal space (posteriorly)
+8. Medial half of the distal third of the diaphysis split longitudinally in the sagittal place, including one-half of the popliteal space (posteriorly(
+9. Lateral condyle and epicondyle
+10. Medial condyle and epicondyle
+11. Intercondylar space and sital articulation anteriorly
 
 ### Patella
 ![Patella](/docs/images/zones/patella_500.png)
+**Left patella. Above: posterior view, Below: anterior view.**
 
 ### Tibia
 ![Tibia](/docs/images/zones/Tibia_left_500.png)
+**Left tibia. Left: posterior view, right: anterior view.**
+
+*Zone descriptions*
+1. medial proximal condyle
+2. Intercondylar fossa between the tibial spines, including the area of attachment of the posterior cruciate ligament
+3. Lateral proximal condyle
+4. Area of the tibial tuberosity
+5. Area of the medial malleolus
+6. Area of the alteral malleolus
+7. Proximal quarter of the diaphysis, including the nutrient forament, posteriorly
+8. Second quarter of the diaphysis
+9. Third quarter of the diaphysis
+10. Distal quarter of the diaphysis
 
 ### Fibula
 ![Fibula](/docs/images/zones/fibula_500.png)
+
 
 ## **Hands and Feet**
 ### Hand

--- a/docs/forensics-anthro-guide/zones.md
+++ b/docs/forensics-anthro-guide/zones.md
@@ -1,1 +1,77 @@
-#This will be Zones
+In this section we present the images used in the Zonation Method for inventory of fragmented human remains.
+#Skull
+##Cranium
+![Skull anterior](cora-docs/docs/images/zones/Clavicle_left_200.png)
+![Skull lateral right](/images/logo.png)
+![Skull lateral left](/images/logo.png)
+![Skull posterior](/images/logo.png)
+![Skull inferior](/images/logo.png)
+![Skull superior](/images/logo.png)
+
+##Mandible
+![Mandible left](/images/logo.png)
+![Mandible right](/images/logo.png)
+
+#Postcranial remains
+##Vertebrae
+###Cervical vertebrae
+![Cervical vertebra](/images/logo.png)
+
+###Thoracic vertebrae
+![Thoracic vertebra](/images/logo.png)
+
+###Lumbar vertebrae
+![Lumbar vertebra](/images/logo.png)
+
+###Sacrum
+![Sacrum](/images/logo.png)
+
+##Thorax and Shoulder
+###Rib 1
+![Rib1](/images/logo.png)
+
+###Ribs 2-12
+![Ribs](/images/logo.png)
+
+###Sternum
+![Sternum](/images/logo.png)
+
+###Clavicle
+![Clavicle](/images/logo.png)
+
+###Scapula
+![Scapula](/images/logo.png)
+
+##Upper limb
+###Humerus
+![Humerus](/images/logo.png)
+
+###Radius
+![Radius](/images/logo.png)
+
+###Ulna
+![Ulna](/images/logo.png)
+
+##Pelvis and Lower Limb
+###Os coxa
+![Os coxa](/images/logo.png)
+
+###Femur
+![Femur](/images/logo.png)
+
+###Patella
+![Patella](/images/logo.png)
+
+###Tibia
+![Tibia](/images/logo.png)
+
+###Fibula
+![Fibula](/images/logo.png)
+
+##Hands and Feet
+###Hand
+![Hand](/images/logo.png)
+
+
+###Foot
+![Foot](/images/logo.png)

--- a/docs/forensics-anthro-guide/zones.md
+++ b/docs/forensics-anthro-guide/zones.md
@@ -62,7 +62,7 @@ In this section we present the images used in the Zonation Method for inventory 
 4. Left parietal
 5. Occipital
 6. Left temporal, including the root of the zygomatic process
-7. Right temporal, including the root of thez ygomatic process
+7. Right temporal, including the root of the zygomatic process
 
 ![Skull inferior](/docs/images/zones/)
 
@@ -74,7 +74,7 @@ In this section we present the images used in the Zonation Method for inventory 
 4. Left parietal
 5. Occipital
 6. Left temporal, including the root of the zygomatic process
-7. Right temporal, including the root of thez ygomatic process
+7. Right temporal, including the root of the zygomatic process
 8. Left sphenoid
 9. Right sphenoid
 10. Left zygomatic bone
@@ -120,14 +120,14 @@ In this section we present the images used in the Zonation Method for inventory 
 
 *Zones*
 
-> 8. Portion of the corpus, including alveoli for the premolars and molars as well as the premolars and molars themselves
-> 9. Portion of the corpus, including alveolus for the canine and the canine itself
-> 10. Area of the ascending ramus inferior to the coronoid process
-> 11. Coronoid process
-> 12. Mandibular condyle
-> 13. Gonial angle, including the mandibular foramen and mylohyoid groove (internally) and the attachment of M. masseter 
+8. Portion of the corpus, including alveoli for the premolars and molars as well as the premolars and molars themselves
+9. Portion of the corpus, including alveolus for the canine and the canine itself
+10. Area of the ascending ramus inferior to the coronoid process
+11. Coronoid process
+12. Mandibular condyle
+13. Gonial angle, including the mandibular foramen and mylohyoid groove (internally) and the attachment of M. masseter 
 externally)
-> 14. Anterior portion of the corpus, including the alveoli of the incisors and the incisors themselves
+14. Anterior portion of the corpus, including the alveoli of the incisors and the incisors themselves
 
 
 # **POSTCRANIAL REMAINS**

--- a/docs/forensics-anthro-guide/zones.md
+++ b/docs/forensics-anthro-guide/zones.md
@@ -1,0 +1,1 @@
+#This will be Zones

--- a/docs/forensics-anthro-guide/zones.md
+++ b/docs/forensics-anthro-guide/zones.md
@@ -365,6 +365,7 @@ Metacarpals and phalanges
 
 ### Foot
 ![Foot](/docs/images/zones/Foot_right_500.png)
+
 **Right foot and ankle. Left: dorsal view, right: plantar view.**
 
 *Zones*

--- a/docs/forensics-anthro-guide/zones.md
+++ b/docs/forensics-anthro-guide/zones.md
@@ -48,6 +48,7 @@ In this section we present the images used in the Zonation Method for inventory 
 14. Left nasal bone
 
 ![Skull posterior](/docs/images/zones/)
+
 **Skull, posterior view**
 
 *Zone descriptions*
@@ -58,6 +59,7 @@ In this section we present the images used in the Zonation Method for inventory 
 7. Right temporal, including the root of thez ygomatic process from the right side
 
 ![Skull inferior](/docs/images/zones/)
+
 **Skull, inferior view**
 
 *Zone descriptions*
@@ -75,6 +77,7 @@ In this section we present the images used in the Zonation Method for inventory 
 
 
 ![Skull superior](/docs/images/zones/)
+
 **Skull, superior view**
 
 *Zone descriptions*
@@ -133,6 +136,7 @@ In this section we present the images used in the Zonation Method for inventory 
 
 ### Thoracic and lumbar vertebrae
 ![Thoracic vertebra](/docs/images/zones/thoracic_500.png)
+
 **Thoracic vertebra (also applies to lumbar vertebrae). Left: superior view, right: lateral view.**
 
 *Zone descriptions*
@@ -143,6 +147,7 @@ In this section we present the images used in the Zonation Method for inventory 
 
 ### Sacrum
 ![Sacrum](/docs/images/zones/Sacrum_500.png)
+
 **Sacrum. Left: anterior view, right: posterior view.**
 
 *Zone descriptions*
@@ -154,6 +159,7 @@ In this section we present the images used in the Zonation Method for inventory 
 ## **Thorax and Shoulder**
 ### Rib 1
 ![Rib1](/docs/images/zones/rib01_500.png)
+
 **Left rib 1. Above: inferior view, below: superior view.**
 
 *Zone descriptions*
@@ -163,6 +169,7 @@ In this section we present the images used in the Zonation Method for inventory 
 
 ### Ribs 2-12
 ![Ribs](/docs/images/zones/ribs_500.png)
+
 **Left rib 7. Above: inferior view, below: superior view.**
 
 *Zone descriptions*
@@ -172,6 +179,7 @@ In this section we present the images used in the Zonation Method for inventory 
 
 ### Sternum
 ![Sternum](/docs/images/zones/Sternum_500.png)
+
 **Sternum. Left: anterior view, right: posterior view.**
 
 *Zone descriptions*
@@ -181,6 +189,7 @@ In this section we present the images used in the Zonation Method for inventory 
 
 ### Clavicle
 ![Clavicle](/docs/images/zones/Clavicle_left_500.png)
+
 **Left clavicle. Above: superior view, below: inferior view.**
 
 *Zone descriptions*
@@ -190,6 +199,7 @@ In this section we present the images used in the Zonation Method for inventory 
 
 ### Scapula
 ![Scapula](/docs/images/zones/Scapula_left_500.png)
+
 **Left scapula. Left: anterior view, right: posterior view.**
 
 *Zone descriptions*
@@ -206,6 +216,7 @@ In this section we present the images used in the Zonation Method for inventory 
 ## **Upper limb**
 ### Humerus
 ![Humerus](/docs/images/zones/Humerus_Left_500.png)
+
 **Left humerus. Left: posterior view, right: anterior view.**
 
 *Zone descriptions*
@@ -223,6 +234,7 @@ In this section we present the images used in the Zonation Method for inventory 
 
 ### Radius
 ![Radius](/docs/images/zones/Radius_left_500.png)
+
 **Left radius. Left: posterior view, right: anterior view.**
 
 *Zone descriptions*
@@ -240,6 +252,7 @@ In this section we present the images used in the Zonation Method for inventory 
 
 ### Ulna
 ![Ulna](/docs/images/zones/Ulna_left_500.png)
+
 **Left ulna. Left: posterior view, right: anterior view.**
 
 *Zone descriptions*
@@ -255,6 +268,7 @@ In this section we present the images used in the Zonation Method for inventory 
 ## **Pelvis and Lower Limb**
 ### Os coxa
 ![Os coxa](/docs/images/zones/Oscoxa_left_500.png)
+
 **Left os coxa. Left: medial/internal view, right: lateral/external view.**
 
 *Zone descriptions*
@@ -273,6 +287,7 @@ In this section we present the images used in the Zonation Method for inventory 
 
 ### Femur
 ![Femur](/docs/images/zones/Femur3_500.png)
+
 **Left femur. Left: posterior view, right: anterior view.**
 
 *Zone descriptions*
@@ -283,20 +298,23 @@ In this section we present the images used in the Zonation Method for inventory 
 5. Neck of the element and area along the inter-trochanteric line (anteriorly) and intertrochanteric crest (posteriorly)
 6. Middle poriton of the diaphysis to the point where the linea aspera bifurcates into the supra-condylar lines, including the nutrient forament, which is located posteriorly
 7. Lateral half of the distal third of the diaphysis split longitudinally in the sagittal plance, including one-half of the popliteal space (posteriorly)
-8. Medial half of the distal third of the diaphysis split longitudinally in the sagittal place, including one-half of the popliteal space (posteriorly(
+8. Medial half of the distal third of the diaphysis split longitudinally in the sagittal place, including one-half of the popliteal space (posteriorly)
 9. Lateral condyle and epicondyle
 10. Medial condyle and epicondyle
 11. Intercondylar space and sital articulation anteriorly
 
 ### Patella
 ![Patella](/docs/images/zones/patella_500.png)
+
 **Left patella. Above: posterior view, Below: anterior view.**
 
 ### Tibia
 ![Tibia](/docs/images/zones/Tibia_left_500.png)
+
 **Left tibia. Left: posterior view, right: anterior view.**
 
 *Zone descriptions*
+
 1. medial proximal condyle
 2. Intercondylar fossa between the tibial spines, including the area of attachment of the posterior cruciate ligament
 3. Lateral proximal condyle
@@ -311,10 +329,57 @@ In this section we present the images used in the Zonation Method for inventory 
 ### Fibula
 ![Fibula](/docs/images/zones/fibula_500.png)
 
+**Left fibula. Left: anterior view, right: posterior view.**
+
+*Zone descriptions*
+
+1. Proximal end, essentially the juvenile epiphysis, including the styloid process
+2. Distal end, essentially the juvenile epiphysis
+3. Most distal quarter of the disphysis, including the attachment fo rhte inferior portion of the interosseious ligament (a triangular rugose region with its apex directed anteriorly)
+4. Middle quarter of the diaphysis, including the nutrient foramen, which is located posteriorly
+5. Second quarter of the disphysis
+6. Most porximal quarter of the diaphysis, distal to the juvenile epiphysis
+
 
 ## **Hands and Feet**
 ### Hand
 ![Hand](/docs/images/zones/Hand_left_500.png)
 
+**Hand and wrist. Left: dorsal right hand, right: palmar left hand.**
+
+*Zone descriptions*
+
+Carpals
+1. Present or absent
+
+Metapodials and phalanges
+1. Proximal articulation
+2. Distal artiuclar condyle
+3. Diaphysis
+
 ### Foot
 ![Foot](/docs/images/zones/Foot_right_500.png)
+**Right foot and ankle. Left: dorsal view, right: plantar view.**
+
+*Zone descriptions*
+
+Calcaneus
+1. Tuber calcis
+2. Distal portion of the body
+3. Sustentaculum tali
+4. Proximal articulation
+5. Proximal portion of the body inferior to the articulations
+
+Talus
+1. Medial half of the trochlea
+2. Lateral half of the trochlea
+3. Medial half of the proximal portion, splitting the head sagittally
+4. Lateral half of the proximal portion, splitting the head sagittally
+
+Remaining tarsals
+1. Present or absent
+
+Metapodials and phalanges
+1. Proximal articulation
+2. Distal artiuclar condyle
+3. Diaphysis

--- a/docs/forensics-anthro-guide/zones.md
+++ b/docs/forensics-anthro-guide/zones.md
@@ -7,90 +7,94 @@ In this section we present the images used in the Zonation Method for inventory 
 **Skull, anterior view.**
 
 *Zones*
-1. Right frontal, split sagittally through the metopic suture
-2. Left frontal, split sagittally through the metopic suture
-3. Right parietal
-4. Left parietal
-6. Left temporal, including the root of the zygomatic process
-7. Right temporal, including the root of the zygomatic process
-10. Left zygomatic bone
-11. Right zygomatic bone
-12. Left maxilla
-13. Right maxilla
-14. Left nasal bone
-15. Right nasal bone
+
+> 1. Right frontal, split sagittally through the metopic suture
+> 2. Left frontal, split sagittally through the metopic suture
+> 3. Right parietal
+> 4. Left parietal
+> 6. Left temporal, including the root of the zygomatic process
+> 7. Right temporal, including the root of the zygomatic process
+> 10. Left zygomatic bone
+> 11. Right zygomatic bone
+> 12. Left maxilla
+> 13. Right maxilla
+> 14. Left nasal bone
+> 15. Right nasal bone
 
 ![Skull lateral right](/docs/images/zones/)
 
 **Skull, lateral right view**
 
 *Zones*
-1. Right frontal, split sagittally through the metopic suture
-3. Right parietal
-5. Occipital
-7. Right temporal, including the root of the zygomatic process
-9. Right sphenoid
-11. Right zygomatic bone
-13. Right maxilla
-15. Right nasal bone
+
+> 1. Right frontal, split sagittally through the metopic suture
+> 3. Right parietal
+> 5. Occipital
+> 7. Right temporal, including the root of the zygomatic process
+> 9. Right sphenoid
+> 11. Right zygomatic bone
+> 13. Right maxilla
+> 15. Right nasal bone
 
 ![Skull lateral left](/docs/images/zones/)
 
 **Skull, lateral left view**
 
 *Zones*
-2. Left frontal, split sagittally through the metopic suture
-4. Left parietal
-5. Occipital
-6. Left temporal, including the root of the zygomatic process
-8. Left sphenoid
-10. Left zygomatic bone
-12. Left maxilla
-14. Left nasal bone
+
+> 2. Left frontal, split sagittally through the metopic suture
+> 4. Left parietal
+> 5. Occipital
+> 6. Left temporal, including the root of the zygomatic process
+> 8. Left sphenoid
+> 10. Left zygomatic bone
+> 12. Left maxilla
+> 14. Left nasal bone
 
 ![Skull posterior](/docs/images/zones/)
 
 **Skull, posterior view**
 
 *Zones*
-3. Right parietal
-4. Left parietal
-5. Occipital
-6. Left temporal, including the root of the zygomatic process
-7. Right temporal, including the root of thez ygomatic process
+
+> 3. Right parietal
+> 4. Left parietal
+> 5. Occipital
+> 6. Left temporal, including the root of the zygomatic process
+> 7. Right temporal, including the root of thez ygomatic process
 
 ![Skull inferior](/docs/images/zones/)
 
 **Skull, inferior view**
 
 *Zones*
-3. Right parietal
-4. Left parietal
-5. Occipital
-6. Left temporal, including the root of the zygomatic process
-7. Right temporal, including the root of thez ygomatic process
-8. Left sphenoid
-9. Right sphenoid
-10. Left zygomatic bone
-11. Right zygomatic bone
-12. Palatal process of the left maxilla
-13. Palatal proces of the right maxilla
 
+> 3. Right parietal
+> 4. Left parietal
+> 5. Occipital
+> 6. Left temporal, including the root of the zygomatic process
+> 7. Right temporal, including the root of thez ygomatic process
+> 8. Left sphenoid
+> 9. Right sphenoid
+> 10. Left zygomatic bone
+> 11. Right zygomatic bone
+> 12. Palatal process of the left maxilla
+> 13. Palatal proces of the right maxilla
 
 ![Skull superior](/docs/images/zones/)
 
 **Skull, superior view**
 
 *Zones*
-1. Right frontal, split sagittally through the metopic suture
-2. Left frontal, split sagittally through the metopic suture
-3. Right parietal
-4. Left parietal
-5. Occipital
-6. Left temporal, including the root of the zygomatic process
-7. Right temporal, including the root of the zygomatic process
-14. Left nasal bone
-15. Right nasal bone
+> 1. Right frontal, split sagittally through the metopic suture
+> 2. Left frontal, split sagittally through the metopic suture
+> 3. Right parietal
+> 4. Left parietal
+> 5. Occipital
+> 6. Left temporal, including the root of the zygomatic process
+> 7. Right temporal, including the root of the zygomatic process
+> 14. Left nasal bone
+> 15. Right nasal bone
 
 
 ## **Mandible**
@@ -112,13 +116,15 @@ In this section we present the images used in the Zonation Method for inventory 
 **Right mandible. Above: medial/internal view, below: lateral/external view.**
 
 *Zones*
-8. Portion of the corpus, including alveoli for the premolars and molars as well as the premolars and molars themselves
-9. Portion of the corpus, including alveolus for the canine and the canine itself
-10. Area of the ascending ramus inferior to the coronoid process
-11. Coronoid process
-12. Mandibular condyle
-13. Gonial angle, including the mandibular foramen and mylohyoid groove (internally) and the attachment of M. masseter externally)
-14. Anterior portion of the corpus, including the alveoli of the incisors and the incisors themselves
+
+> 8. Portion of the corpus, including alveoli for the premolars and molars as well as the premolars and molars themselves
+> 9. Portion of the corpus, including alveolus for the canine and the canine itself
+> 10. Area of the ascending ramus inferior to the coronoid process
+> 11. Coronoid process
+> 12. Mandibular condyle
+> 13. Gonial angle, including the mandibular foramen and mylohyoid groove (internally) and the attachment of M. masseter 
+externally)
+> 14. Anterior portion of the corpus, including the alveoli of the incisors and the incisors themselves
 
 
 # **POSTCRANIAL REMAINS**

--- a/docs/forensics-anthro-guide/zones.md
+++ b/docs/forensics-anthro-guide/zones.md
@@ -27,14 +27,14 @@ In this section we present the images used in the Zonation Method for inventory 
 
 *Zones*
 
-> 1. Right frontal, split sagittally through the metopic suture
-> 3. Right parietal
-> 5. Occipital
-> 7. Right temporal, including the root of the zygomatic process
-> 9. Right sphenoid
-> 11. Right zygomatic bone
-> 13. Right maxilla
-> 15. Right nasal bone
+1. Right frontal, split sagittally through the metopic suture
+3. Right parietal
+5. Occipital
+7. Right temporal, including the root of the zygomatic process
+9. Right sphenoid
+11. Right zygomatic bone
+13. Right maxilla
+15. Right nasal bone
 
 ![Skull lateral left](/docs/images/zones/)
 
@@ -57,11 +57,11 @@ In this section we present the images used in the Zonation Method for inventory 
 
 *Zones*
 
-> 3. Right parietal
-> 4. Left parietal
-> 5. Occipital
-> 6. Left temporal, including the root of the zygomatic process
-> 7. Right temporal, including the root of thez ygomatic process
+3. Right parietal
+4. Left parietal
+5. Occipital
+6. Left temporal, including the root of the zygomatic process
+7. Right temporal, including the root of thez ygomatic process
 
 ![Skull inferior](/docs/images/zones/)
 

--- a/docs/forensics-anthro-guide/zones.md
+++ b/docs/forensics-anthro-guide/zones.md
@@ -1,4 +1,5 @@
-In this section we present the images used in the Zonation Method for inventory of fragmented human remains.
+In this section we present the images used in the Zonation Method for inventory of fragmented human remains, along with captions and desciptions of each of the zones.
+
 # **SKULL**
 ## **Cranium**
 ![Skull anterior](/docs/images/zones/)
@@ -7,13 +8,13 @@ In this section we present the images used in the Zonation Method for inventory 
 
 *Zone descriptions*
 1. Right frontal, split sagittally through the metopic suture
-2. Left frontal, split sagittally through the juvenile metopic suture
+2. Left frontal, split sagittally through the metopic suture
 3. Right parietal
 4. Left parietal
-6. Left temporal, including the root of the zygomatic process from the left side
-7. Right temporal, including the root of thez ygomatic process from the right side
-10. Left zygoma
-11. Right zygoma
+6. Left temporal, including the root of the zygomatic process
+7. Right temporal, including the root of the zygomatic process
+10. Left zygomatic bone
+11. Right zygomatic bone
 12. Left maxilla
 13. Right maxilla
 14. Left nasal bone
@@ -27,9 +28,9 @@ In this section we present the images used in the Zonation Method for inventory 
 1. Right frontal, split sagittally through the metopic suture
 3. Right parietal
 5. Occipital
-7. Right temporal, including the root of thez ygomatic process from the right side
+7. Right temporal, including the root of the zygomatic process
 9. Right sphenoid
-11. Right zygoma
+11. Right zygomatic bone
 13. Right maxilla
 15. Right nasal bone
 
@@ -38,12 +39,12 @@ In this section we present the images used in the Zonation Method for inventory 
 **Skull, lateral left view**
 
 *Zone descriptions*
-2. Left frontal, split sagittally through the juvenile metopic suture
+2. Left frontal, split sagittally through the metopic suture
 4. Left parietal
 5. Occipital
-6. Left temporal, including the root of the zygomatic process from the left side
+6. Left temporal, including the root of the zygomatic process
 8. Left sphenoid
-10. Left zygoma
+10. Left zygomatic bone
 12. Left maxilla
 14. Left nasal bone
 
@@ -55,8 +56,8 @@ In this section we present the images used in the Zonation Method for inventory 
 3. Right parietal
 4. Left parietal
 5. Occipital
-6. Left temporal, including the root of the zygomatic process from the left side
-7. Right temporal, including the root of thez ygomatic process from the right side
+6. Left temporal, including the root of the zygomatic process
+7. Right temporal, including the root of thez ygomatic process
 
 ![Skull inferior](/docs/images/zones/)
 
@@ -66,12 +67,12 @@ In this section we present the images used in the Zonation Method for inventory 
 3. Right parietal
 4. Left parietal
 5. Occipital
-6. Left temporal, including the root of the zygomatic process from the left side
-7. Right temporal, including the root of thez ygomatic process from the right side
+6. Left temporal, including the root of the zygomatic process
+7. Right temporal, including the root of thez ygomatic process
 8. Left sphenoid
 9. Right sphenoid
-10. Left zygoma
-11. Right zygoma
+10. Left zygomatic bone
+11. Right zygomatic bone
 12. Palatal process of the left maxilla
 13. Palatal proces of the right maxilla
 
@@ -82,12 +83,12 @@ In this section we present the images used in the Zonation Method for inventory 
 
 *Zone descriptions*
 1. Right frontal, split sagittally through the metopic suture
-2. Left frontal, split sagittally through the juvenile metopic suture
+2. Left frontal, split sagittally through the metopic suture
 3. Right parietal
 4. Left parietal
 5. Occipital
-6. Left temporal, including the root of the zygomatic process from the left side
-7. Right temporal, including the root of thez ygomatic process from the right side
+6. Left temporal, including the root of the zygomatic process
+7. Right temporal, including the root of the zygomatic process
 14. Left nasal bone
 15. Right nasal bone
 
@@ -98,27 +99,26 @@ In this section we present the images used in the Zonation Method for inventory 
 **Left mandible. Above: medial/internal view, below: lateral/external view.**
 
 *Zone descriptions*
-1. The portion of the corpus, including the alveoli for the premolars and molars as well as the premolars and molars themselves
-2. The portion of the corpus, including the alveolus fo rthe canine and the canine itself
-3. The area of the ascending ramus inferior to the coronoid process
-4. The coronoid process
-5. The mandibular condyle
-6. The gonial angle, including the mandibular foramen and mylohyoid groove (internally) and the attachment of M. masseter externally)
-7. The anterior portion of the corpus, includin the alveoli of the icisors and the incisors themselves
+1. Portion of the corpus, including alveoli for the premolars and molars as well as the premolars and molars themselves
+2. Portion of the corpus, including alveolus for the canine and the canine itself
+3. Area of the ascending ramus inferior to the coronoid process
+4. Coronoid process
+5. Mandibular condyle
+6. Gonial angle, including the mandibular foramen and mylohyoid groove (internally) and the attachment of M. masseter externally)
+7. Anterior portion of the corpus, including the alveoli of the incisors and the incisors themselves
 
 ![Mandible right](/docs/images/zones/Mandible_right_500.png)
 
 **Right mandible. Above: medial/internal view, below: lateral/external view.**
 
 *Zone descriptions*
-8. The portion of the corpus, including the alveoli for the premolars and molars as well as the premolars and molars themselves
-9. The portion of the corpus, including the alveolus fo rthe canine and the canine itself
-10. The area of the ascending ramus inferior to the coronoid process
-11. The coronoid process
-12. The mandibular condyle
-13. The gonial angle, including the mandibular foramen and mylohyoid groove (internally) and the attachment of M. masseter externally)
-14. The anterior portion of the corpus, includin the alveoli of the icisors and the incisors themselves
-
+8. Portion of the corpus, including alveoli for the premolars and molars as well as the premolars and molars themselves
+9. Portion of the corpus, including alveolus for the canine and the canine itself
+10. Area of the ascending ramus inferior to the coronoid process
+11. Coronoid process
+12. Mandibular condyle
+13. Gonial angle, including the mandibular foramen and mylohyoid groove (internally) and the attachment of M. masseter externally)
+14. Anterior portion of the corpus, including the alveoli of the incisors and the incisors themselves
 
 
 # **POSTCRANIAL REMAINS**
@@ -130,8 +130,8 @@ In this section we present the images used in the Zonation Method for inventory 
 
 *Zone descriptions*
 1. Body
-2. Right transverse process, including the pedicle, pars interaticularis, and articular facets
-3. Left transverse process, including the pedicle, pars interaticularis, and aricular facets
+2. Right transverse process, including the pedicle, pars interarticularis, and articular facets
+3. Left transverse process, including the pedicle, pars interarticularis, and articular facets
 4. Spinous process
 
 ### Thoracic and lumbar vertebrae
@@ -141,8 +141,8 @@ In this section we present the images used in the Zonation Method for inventory 
 
 *Zone descriptions*
 1. Body
-2. Right transverse process, including the pedicle, pars interaticularis, and articular facets
-3. Left transverse process, including the pedicle, pars interaticularis, and aricular facets
+2. Right transverse process, including the pedicle, pars interarticularis, and articular facets
+3. Left transverse process, including the pedicle, pars interarticularis, and articular facets
 4. Spinous process
 
 ### Sacrum
@@ -152,8 +152,8 @@ In this section we present the images used in the Zonation Method for inventory 
 
 *Zone descriptions*
 1. Body
-2. Right transverse process, including the pedicle, pars interaticularis, and articular facets
-3. Left transverse process, including the pedicle, pars interaticularis, and aricular facets
+2. Right transverse process, including the pedicle, pars interarticularis, and articular facets
+3. Left transverse process, including the pedicle, pars interarticularis, and articular facets
 4. Spinous process
 
 ## **Thorax and Shoulder**
@@ -193,9 +193,9 @@ In this section we present the images used in the Zonation Method for inventory 
 **Left clavicle. Above: superior view, below: inferior view.**
 
 *Zone descriptions*
-1. Sternal end, including the area fo the atachment fo rthe cost-clavicular ligament
-2. Acromial end, including the conoid tubecle and trapezoid line, the attachments for the two components of the coraco-clavicular ligament
-3. Diaphysis, including the groove which marks the attachment for M. subclavius
+1. Sternal end, including the area of the atachment for the costo-clavicular ligament
+2. Acromial end, including the conoid tubecle and trapezoid line
+3. Diaphysis, including the groove that marks the attachment for M. subclavius
 
 ### Scapula
 ![Scapula](/docs/images/zones/Scapula_left_500.png)
@@ -204,12 +204,12 @@ In this section we present the images used in the Zonation Method for inventory 
 
 *Zone descriptions*
 1. Coracoid process
-2. Superior half of the gelnoid cavity
+2. Superior half of the glenoid cavity
 3. Inferior half of the glenoid cavity
-4. Acromial end and axillary third of the spine
-5. Axillary third of the squamous portion and spine, including the neck and the area inferior to the coracoid process
+4. Acromial end and axillary/lateral third of the spine
+5. Axillary/lateral third of the squamous portion and spine, including the neck and the area inferior to the coracoid process
 6. Middle third of the supraspinous fossa
-7. Axillary half of the squamous portion inferior to the spine, including the infraspinous fossa
+7. Axillary/lateral half of the squamous portion inferior to the spine, including the infraspinous fossa
 8. Vertebral third of the squamous portion and spine, including the attachment for M. rhomboideus major and suprasprinous fossa
 9. Vertebral half of the squamous portion inferior to the spine, including the infraspinous fossa
 
@@ -227,9 +227,9 @@ In this section we present the images used in the Zonation Method for inventory 
 5. Lateral articular process (capitulum) of the condyle
 6. Medial articular process (trochlea) of the condyle
 7. Distal lateral half of the diaphysis, including one-half of the olecranon fossa and the radial fossa
-8. Distal medial half of the diaphysis, including one-half of the olecranon fosssa and the coronoid fossa, including the nutrient forament
-9. Area surroudning the deltoid tuberosity
-10. Area opposite 9 making up one-half of the diaphysis longitudinally in the sagittal plane and cutting the bone transversely from medial to lateral
+8. Distal medial half of the diaphysis, including one-half of the olecranon fosssa and the coronoid fossa, including the nutrient foramen
+9. Area surrounding the deltoid tuberosity
+10. Area opposite zone 9 making up one-half of the diaphysis longitudinally in the sagittal plane and cutting the bone transversely from medial to lateral
 11. Proximal portion of the diaphysis, including the surgical neck
 
 ### Radius
@@ -243,8 +243,8 @@ In this section we present the images used in the Zonation Method for inventory 
 3. Lateral portion of the distal articulation
 4. Medial portion of the distal articulation
 5. Proximal portion of the diaphysis, including the radial tuberosity
-6. Lateral half o fthe diaphysis to the mid-point of the diaphysis, including the attachment for M. pronator teres
-7. Medial half of diaphysis to the mid-point of the diaphysis, opposite zone 6, including hte nutrient forament, which is located antero-medially
+6. Lateral half of the diaphysis to the mid-point of the diaphysis, including the attachment for M. pronator teres
+7. Medial half of diaphysis to the mid-point of the diaphysis, opposite zone 6, including the nutrient foramen, which is located antero-medially
 8. Superior half of the distal third of the radius
 9. Lateral distal third of the diaphysis
 10. Medial distal third of the diaphysis
@@ -259,10 +259,10 @@ In this section we present the images used in the Zonation Method for inventory 
 1. Olecranon process
 2. Area of the trochlear or semi-lunar notch, including the coronoid process
 3. Radial notch
-4. Proximal half of the diaphysis distal to area C
-5. Middle portion of the shaft
+4. Proximal half of the diaphysis distal to zone 3
+5. Middle portion of the diaphysis
 6. Superior one-half of the distal third of the diaphysis
-7. Distal half of the distal third of the shaft, including the attachment of M. pronator quadratus
+7. Distal half of the distal third of the diaphysis, including the attachment of M. pronator quadratus
 8. Styloid process and head, including the posterior groove for M. extensor carpi ulnaris
 
 ## **Pelvis and Lower Limb**
@@ -276,12 +276,12 @@ In this section we present the images used in the Zonation Method for inventory 
 2. Posterior half of the inferior portion of the acetabulum and adjoining areas
 3. Anterior half of the inferior portion of the acetabulum and adjoining areas
 4. Superior portion of the ischium, including the ischial spine
-5. Inferior portion of the ilium, including the greater sicatic notch
+5. Inferior portion of the ilium, including the greater sciatic notch
 6. Superior portion of the ischial tuberosity
 7. Auricular surface of the ilium
 8. Superior portion of the pubis possessing the pectineal line and pubic tubercle
 9. Inferior portion of the pubis, including the pubic symphysis
-10. Greater part of the ilium, marked in an atnero-posterior diretion by a line running from just inferior to the anterior superior iliac spine to the posterior inferior iliac spine, but not including the iliac ccrest (superiorly)
+10. Greater part of the ilium, marked in an antero-posterior diretion by a line running from just inferior to the anterior superior iliac spine to the posterior inferior iliac spine, but not including the iliac crest (superiorly)
 11. Inferior portion of the ischial tuberosity
 12. Iliac crest
 
@@ -296,12 +296,12 @@ In this section we present the images used in the Zonation Method for inventory 
 3. Area of the cranial attachment of M. gluteus maximus
 4. Caput
 5. Neck of the element and area along the inter-trochanteric line (anteriorly) and intertrochanteric crest (posteriorly)
-6. Middle poriton of the diaphysis to the point where the linea aspera bifurcates into the supra-condylar lines, including the nutrient forament, which is located posteriorly
-7. Lateral half of the distal third of the diaphysis split longitudinally in the sagittal plance, including one-half of the popliteal space (posteriorly)
+6. Middle portion of the diaphysis to the point where the linea aspera bifurcates into the supra-condylar lines, including the nutrient forament, which is located posteriorly
+7. Lateral half of the distal third of the diaphysis split longitudinally in the sagittal plane, including one-half of the popliteal space (posteriorly)
 8. Medial half of the distal third of the diaphysis split longitudinally in the sagittal place, including one-half of the popliteal space (posteriorly)
 9. Lateral condyle and epicondyle
 10. Medial condyle and epicondyle
-11. Intercondylar space and sital articulation anteriorly
+11. Intercondylar space and distal articulation anteriorly
 
 ### Patella
 ![Patella](/docs/images/zones/patella_500.png)
@@ -315,13 +315,13 @@ In this section we present the images used in the Zonation Method for inventory 
 
 *Zone descriptions*
 
-1. medial proximal condyle
+1. Medial proximal condyle
 2. Intercondylar fossa between the tibial spines, including the area of attachment of the posterior cruciate ligament
 3. Lateral proximal condyle
 4. Area of the tibial tuberosity
 5. Area of the medial malleolus
-6. Area of the alteral malleolus
-7. Proximal quarter of the diaphysis, including the nutrient forament, posteriorly
+6. Area of the lateral malleolus
+7. Proximal quarter of the diaphysis, including the nutrient foramen, which is located posteriorly
 8. Second quarter of the diaphysis
 9. Third quarter of the diaphysis
 10. Distal quarter of the diaphysis
@@ -335,10 +335,10 @@ In this section we present the images used in the Zonation Method for inventory 
 
 1. Proximal end, essentially the juvenile epiphysis, including the styloid process
 2. Distal end, essentially the juvenile epiphysis
-3. Most distal quarter of the disphysis, including the attachment fo rhte inferior portion of the interosseious ligament (a triangular rugose region with its apex directed anteriorly)
+3. Most distal quarter of the diaphysis, including the attachment for the inferior portion of the interosseous ligament (a triangular rugose region with its apex directed anteriorly)
 4. Middle quarter of the diaphysis, including the nutrient foramen, which is located posteriorly
-5. Second quarter of the disphysis
-6. Most porximal quarter of the diaphysis, distal to the juvenile epiphysis
+5. Second quarter of the diaphysis
+6. Most proximal quarter of the diaphysis, distal to the juvenile epiphysis
 
 
 ## **Hands and Feet**
@@ -352,7 +352,7 @@ In this section we present the images used in the Zonation Method for inventory 
 Carpals
 1. Present or absent
 
-Metapodials and phalanges
+Metacarpals and phalanges
 1. Proximal articulation
 2. Distal artiuclar condyle
 3. Diaphysis
@@ -379,7 +379,7 @@ Talus
 Remaining tarsals
 1. Present or absent
 
-Metapodials and phalanges
+Metatarsals and phalanges
 1. Proximal articulation
 2. Distal artiuclar condyle
 3. Diaphysis

--- a/docs/forensics-anthro-guide/zones.md
+++ b/docs/forensics-anthro-guide/zones.md
@@ -2,24 +2,25 @@ In this section we present the images used in the Zonation Method for inventory 
 
 # **SKULL**
 ## **Cranium**
+
 ![Skull anterior](/docs/images/zones/)
 
 **Skull, anterior view.**
 
 *Zones*
 
-> 1. Right frontal, split sagittally through the metopic suture
-> 2. Left frontal, split sagittally through the metopic suture
-> 3. Right parietal
-> 4. Left parietal
-> 6. Left temporal, including the root of the zygomatic process
-> 7. Right temporal, including the root of the zygomatic process
-> 10. Left zygomatic bone
-> 11. Right zygomatic bone
-> 12. Left maxilla
-> 13. Right maxilla
-> 14. Left nasal bone
-> 15. Right nasal bone
+1. Right frontal, split sagittally through the metopic suture
+2. Left frontal, split sagittally through the metopic suture
+3. Right parietal
+4. Left parietal
+6. Left temporal, including the root of the zygomatic process
+7. Right temporal, including the root of the zygomatic process
+10. Left zygomatic bone
+11. Right zygomatic bone
+12. Left maxilla
+13. Right maxilla
+14. Left nasal bone
+15. Right nasal bone
 
 ![Skull lateral right](/docs/images/zones/)
 
@@ -42,14 +43,14 @@ In this section we present the images used in the Zonation Method for inventory 
 
 *Zones*
 
-> 2. Left frontal, split sagittally through the metopic suture
-> 4. Left parietal
-> 5. Occipital
-> 6. Left temporal, including the root of the zygomatic process
-> 8. Left sphenoid
-> 10. Left zygomatic bone
-> 12. Left maxilla
-> 14. Left nasal bone
+2. Left frontal, split sagittally through the metopic suture
+4. Left parietal
+5. Occipital
+6. Left temporal, including the root of the zygomatic process
+8. Left sphenoid
+10. Left zygomatic bone
+12. Left maxilla
+14. Left nasal bone
 
 ![Skull posterior](/docs/images/zones/)
 
@@ -69,35 +70,37 @@ In this section we present the images used in the Zonation Method for inventory 
 
 *Zones*
 
-> 3. Right parietal
-> 4. Left parietal
-> 5. Occipital
-> 6. Left temporal, including the root of the zygomatic process
-> 7. Right temporal, including the root of thez ygomatic process
-> 8. Left sphenoid
-> 9. Right sphenoid
-> 10. Left zygomatic bone
-> 11. Right zygomatic bone
-> 12. Palatal process of the left maxilla
-> 13. Palatal proces of the right maxilla
+3. Right parietal
+4. Left parietal
+5. Occipital
+6. Left temporal, including the root of the zygomatic process
+7. Right temporal, including the root of thez ygomatic process
+8. Left sphenoid
+9. Right sphenoid
+10. Left zygomatic bone
+11. Right zygomatic bone
+12. Palatal process of the left maxilla
+13. Palatal proces of the right maxilla
 
 ![Skull superior](/docs/images/zones/)
 
 **Skull, superior view**
 
 *Zones*
-> 1. Right frontal, split sagittally through the metopic suture
-> 2. Left frontal, split sagittally through the metopic suture
-> 3. Right parietal
-> 4. Left parietal
-> 5. Occipital
-> 6. Left temporal, including the root of the zygomatic process
-> 7. Right temporal, including the root of the zygomatic process
-> 14. Left nasal bone
-> 15. Right nasal bone
+
+1. Right frontal, split sagittally through the metopic suture
+2. Left frontal, split sagittally through the metopic suture
+3. Right parietal
+4. Left parietal
+5. Occipital
+6. Left temporal, including the root of the zygomatic process
+7. Right temporal, including the root of the zygomatic process
+14. Left nasal bone
+15. Right nasal bone
 
 
 ## **Mandible**
+
 ![Mandible left](/docs/images/zones/Mandible_left_500.png)
 
 **Left mandible. Above: medial/internal view, below: lateral/external view.**

--- a/docs/forensics-anthro-guide/zones.md
+++ b/docs/forensics-anthro-guide/zones.md
@@ -6,7 +6,7 @@ In this section we present the images used in the Zonation Method for inventory 
 
 **Skull, anterior view.**
 
-*Zone descriptions*
+*Zones*
 1. Right frontal, split sagittally through the metopic suture
 2. Left frontal, split sagittally through the metopic suture
 3. Right parietal
@@ -24,7 +24,7 @@ In this section we present the images used in the Zonation Method for inventory 
 
 **Skull, lateral right view**
 
-*Zone descriptions*
+*Zones*
 1. Right frontal, split sagittally through the metopic suture
 3. Right parietal
 5. Occipital
@@ -38,7 +38,7 @@ In this section we present the images used in the Zonation Method for inventory 
 
 **Skull, lateral left view**
 
-*Zone descriptions*
+*Zones*
 2. Left frontal, split sagittally through the metopic suture
 4. Left parietal
 5. Occipital
@@ -52,7 +52,7 @@ In this section we present the images used in the Zonation Method for inventory 
 
 **Skull, posterior view**
 
-*Zone descriptions*
+*Zones*
 3. Right parietal
 4. Left parietal
 5. Occipital
@@ -63,7 +63,7 @@ In this section we present the images used in the Zonation Method for inventory 
 
 **Skull, inferior view**
 
-*Zone descriptions*
+*Zones*
 3. Right parietal
 4. Left parietal
 5. Occipital
@@ -81,7 +81,7 @@ In this section we present the images used in the Zonation Method for inventory 
 
 **Skull, superior view**
 
-*Zone descriptions*
+*Zones*
 1. Right frontal, split sagittally through the metopic suture
 2. Left frontal, split sagittally through the metopic suture
 3. Right parietal
@@ -98,7 +98,7 @@ In this section we present the images used in the Zonation Method for inventory 
 
 **Left mandible. Above: medial/internal view, below: lateral/external view.**
 
-*Zone descriptions*
+*Zones*
 1. Portion of the corpus, including alveoli for the premolars and molars as well as the premolars and molars themselves
 2. Portion of the corpus, including alveolus for the canine and the canine itself
 3. Area of the ascending ramus inferior to the coronoid process
@@ -111,7 +111,7 @@ In this section we present the images used in the Zonation Method for inventory 
 
 **Right mandible. Above: medial/internal view, below: lateral/external view.**
 
-*Zone descriptions*
+*Zones*
 8. Portion of the corpus, including alveoli for the premolars and molars as well as the premolars and molars themselves
 9. Portion of the corpus, including alveolus for the canine and the canine itself
 10. Area of the ascending ramus inferior to the coronoid process
@@ -128,7 +128,7 @@ In this section we present the images used in the Zonation Method for inventory 
 
 **Cervical vertebra. Left: superior view, right: lateral view.**
 
-*Zone descriptions*
+*Zones*
 1. Body
 2. Right transverse process, including the pedicle, pars interarticularis, and articular facets
 3. Left transverse process, including the pedicle, pars interarticularis, and articular facets
@@ -139,7 +139,7 @@ In this section we present the images used in the Zonation Method for inventory 
 
 **Thoracic vertebra (also applies to lumbar vertebrae). Left: superior view, right: lateral view.**
 
-*Zone descriptions*
+*Zones*
 1. Body
 2. Right transverse process, including the pedicle, pars interarticularis, and articular facets
 3. Left transverse process, including the pedicle, pars interarticularis, and articular facets
@@ -150,7 +150,7 @@ In this section we present the images used in the Zonation Method for inventory 
 
 **Sacrum. Left: anterior view, right: posterior view.**
 
-*Zone descriptions*
+*Zones*
 1. Body
 2. Right transverse process, including the pedicle, pars interarticularis, and articular facets
 3. Left transverse process, including the pedicle, pars interarticularis, and articular facets
@@ -162,7 +162,7 @@ In this section we present the images used in the Zonation Method for inventory 
 
 **Left rib 1. Above: inferior view, below: superior view.**
 
-*Zone descriptions*
+*Zons*
 1. Head
 2. Area of the angle of the rib, including the articular and non-articular costal facets in ribs 1 through 10
 3. Remaining corpus and sternal end
@@ -172,7 +172,7 @@ In this section we present the images used in the Zonation Method for inventory 
 
 **Left rib 7. Above: inferior view, below: superior view.**
 
-*Zone descriptions*
+*Zones*
 1. Head
 2. Area of the angle of the rib, including the articular and non-articular costal facets in ribs 1 through 10
 3. Remaining corpus and sternal end
@@ -182,7 +182,7 @@ In this section we present the images used in the Zonation Method for inventory 
 
 **Sternum. Left: anterior view, right: posterior view.**
 
-*Zone descriptions*
+*Zones*
 1. Manubrium
 2. Corpus sterni
 3. Xiphoid process
@@ -192,7 +192,7 @@ In this section we present the images used in the Zonation Method for inventory 
 
 **Left clavicle. Above: superior view, below: inferior view.**
 
-*Zone descriptions*
+*Zones*
 1. Sternal end, including the area of the atachment for the costo-clavicular ligament
 2. Acromial end, including the conoid tubecle and trapezoid line
 3. Diaphysis, including the groove that marks the attachment for M. subclavius
@@ -202,7 +202,7 @@ In this section we present the images used in the Zonation Method for inventory 
 
 **Left scapula. Left: anterior view, right: posterior view.**
 
-*Zone descriptions*
+*Zones*
 1. Coracoid process
 2. Superior half of the glenoid cavity
 3. Inferior half of the glenoid cavity
@@ -219,7 +219,7 @@ In this section we present the images used in the Zonation Method for inventory 
 
 **Left humerus. Left: posterior view, right: anterior view.**
 
-*Zone descriptions*
+*Zones*
 1. Greater and lesser tubercles
 2. Caput
 3. Lateral epicondyle
@@ -237,7 +237,7 @@ In this section we present the images used in the Zonation Method for inventory 
 
 **Left radius. Left: posterior view, right: anterior view.**
 
-*Zone descriptions*
+*Zones*
 1. Lateral half of the radial head
 2. Medial half of the radial head
 3. Lateral portion of the distal articulation
@@ -255,7 +255,7 @@ In this section we present the images used in the Zonation Method for inventory 
 
 **Left ulna. Left: posterior view, right: anterior view.**
 
-*Zone descriptions*
+*Zones*
 1. Olecranon process
 2. Area of the trochlear or semi-lunar notch, including the coronoid process
 3. Radial notch
@@ -271,7 +271,7 @@ In this section we present the images used in the Zonation Method for inventory 
 
 **Left os coxa. Left: medial/internal view, right: lateral/external view.**
 
-*Zone descriptions*
+*Zones*
 1. Superior portion of the acetabulum and adjoining areas anteriorly and posteriorly
 2. Posterior half of the inferior portion of the acetabulum and adjoining areas
 3. Anterior half of the inferior portion of the acetabulum and adjoining areas
@@ -290,7 +290,7 @@ In this section we present the images used in the Zonation Method for inventory 
 
 **Left femur. Left: posterior view, right: anterior view.**
 
-*Zone descriptions*
+*Zones*
 1. Greater trochanter
 2. Area around the lesser trochanter and the lesser trochanter
 3. Area of the cranial attachment of M. gluteus maximus
@@ -313,7 +313,7 @@ In this section we present the images used in the Zonation Method for inventory 
 
 **Left tibia. Left: posterior view, right: anterior view.**
 
-*Zone descriptions*
+*Zones*
 
 1. Medial proximal condyle
 2. Intercondylar fossa between the tibial spines, including the area of attachment of the posterior cruciate ligament
@@ -331,7 +331,7 @@ In this section we present the images used in the Zonation Method for inventory 
 
 **Left fibula. Left: anterior view, right: posterior view.**
 
-*Zone descriptions*
+*Zones*
 
 1. Proximal end, essentially the juvenile epiphysis, including the styloid process
 2. Distal end, essentially the juvenile epiphysis
@@ -347,7 +347,7 @@ In this section we present the images used in the Zonation Method for inventory 
 
 **Hand and wrist. Left: dorsal right hand, right: palmar left hand.**
 
-*Zone descriptions*
+*Zones*
 
 Carpals
 1. Present or absent
@@ -361,7 +361,7 @@ Metacarpals and phalanges
 ![Foot](/docs/images/zones/Foot_right_500.png)
 **Right foot and ankle. Left: dorsal view, right: plantar view.**
 
-*Zone descriptions*
+*Zones*
 
 Calcaneus
 1. Tuber calcis


### PR DESCRIPTION
I have created a first draft of the Zones document for the forensics-anthro-guide. 

I am having trouble with simple lines in markdown, where the first few "ordered lists" won't recognize as such because they skip numbers or start with "8." etc. Using '> ' creates a "block quote", which makes the line spacing good, but these then look different from my other lists. And I misunderstood inserting "code" in the cheat sheet, so adding '<p>' shows <p> instead of doing the command. Hoping you guys can help!

Thanks,
Emily